### PR TITLE
Add support for provisioner-less base boxes

### DIFF
--- a/lib/kitchen/provisioner/windows_chef_zero.rb
+++ b/lib/kitchen/provisioner/windows_chef_zero.rb
@@ -10,7 +10,7 @@ module Kitchen
     class WindowsChefZero < ChefZero
 
       default_config :sudo, false
-      default_config :require_chef_omnibus, false
+      default_config :chef_omnibus_url, 'http://www.getchef.com/chef/install.msi'
       default_config :windows_root_path, 'C:\Windows\Temp\kitchen'
       default_config :windows_chef_bindir, 'C:\opscode\chef\bin'
       default_config :disabled_ohai_plugins, %w[
@@ -20,16 +20,31 @@ module Kitchen
         windows::virtualization windows::kernel_devices
       ]
 
+      # It would be difficult to make the existing
+      # `Kitchen::Provisioner::ChefBase#install_command`
+      # Windows-friendly so we'll just make it no-op.
+      def install_command
+      end
+
       def create_sandbox
         super
+        prepare_install_ps1
         prepare_chef_client_zero_rb
         prepare_validation_pem
         prepare_client_rb
         prepare_run_script
       end
 
+      # We're hacking Test Kitchen's life-cycle a little here but YOLO.
       def run_command
-        File.join(config[:root_path], "run_client.bat")
+        cmds = []
+        cmds << install_chef_command
+        cmds << File.join(config[:windows_root_path], 'run_client.bat')
+        # Since these commands most likely run under cygwin's `/bin/sh`
+        # let's make sure all paths have forward slashes.
+        cmds.map do |cmd|
+          cmd.gsub("\\", '/')
+        end.join('; ')
       end
 
       private
@@ -82,6 +97,37 @@ module Kitchen
         File.open(File.join(sandbox_path, "run_client.bat"), "wb") do |file|
           file.write(windows_run_command)
         end
+      end
+
+      def prepare_install_ps1
+        chef_version = config[:require_chef_omnibus] || 'latest'
+        File.open(File.join(sandbox_path, "install.ps1"), "wb") do |file|
+          file.write <<-INSTALL.gsub(/^ {12}/, '')
+            $env:Path = "C:\\opscode\\chef\\bin"
+
+            # Retrieve current Chef version
+            try {
+              $installed_chef_version = [string](chef-solo -v)
+            } catch [Exception] {
+              $installed_chef_version = ''
+            }
+
+            # If the current and desired versions don't match
+            # install Chef.
+            if (-Not ($installed_chef_version -match '#{chef_version}')) {
+              Write-Host "-----> Installing Chef Omnibus (#{chef_version})"
+              $downloader = New-Object System.Net.WebClient
+              $download_path = Join-Path '#{config[:windows_root_path]}' 'chef-client-#{chef_version}.windows.msi'
+              $downloader.DownloadFile('#{config[:chef_omnibus_url]}?v=#{chef_version}', $download_path)
+              $install_process = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/q /i $download_path" -Wait -Passthru
+            }
+          INSTALL
+        end
+      end
+
+      def install_chef_command
+        install_script_path = File.join(config[:windows_root_path], 'install.ps1')
+        "powershell.exe -InputFormat None -ExecutionPolicy bypass -File #{install_script_path}"
       end
     end
   end


### PR DESCRIPTION
Idempotently ensure the desired version of the Omnibus Chef MSI is installed. We install Chef during the `run_command` stage so we can use the sandbox to transfer `install.ps1` (basically a Window's version of `install.sh`).

Tested with a Chef-less box produced from @misheska's Packer templates:
https://github.com/misheska/basebox-packer/tree/master/template
