### PR TITLE
fix path in install.ps1

### DIFF
--- a/lib/kitchen/provisioner/windows_chef_zero.rb
+++ b/lib/kitchen/provisioner/windows_chef_zero.rb
@@ -109,7 +109,7 @@ module Kitchen
 
         File.open(File.join(sandbox_path, "install.ps1"), "wb") do |file|
           file.write <<-INSTALL.gsub(/^ {12}/, "")
-            $env:Path = "C:\\opscode\\chef\\bin"
+            $env:Path = "C:\\opscode\\chef\\bin;C:\\opscode\\chef\\embedded\\bin"
 
             # Retrieve current Chef version
             try {


### PR DESCRIPTION
not sure if its only me but the chef-solo.bat of the chef 11.14.2 msi contains the following line:

```
@"ruby.exe" "%~dpn0" %*
```

This does not work when the embedded\bin directory is not in the path
